### PR TITLE
Release v0.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-sudo: false
+os: linux
 services:
   - docker
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
@@ -8,9 +8,12 @@ env:
   global:
     - PACKAGE=mock
     - DISTRO=alpine
-  matrix:
-    - OCAML_VERSION=4.04 PACKAGE=mock-ounit PINS=mock:https://github.com/cryptosense/ocaml-mock.git
+  jobs:
     - OCAML_VERSION=4.04
     - OCAML_VERSION=4.05
     - OCAML_VERSION=4.06
-    - OCAML_VERSION=4.06 PACKAGE=mock-ounit PINS=mock:https://github.com/cryptosense/ocaml-mock.git
+    - OCAML_VERSION=4.07
+    - OCAML_VERSION=4.08
+    - OCAML_VERSION=4.09
+    - OCAML_VERSION=4.04 PACKAGE=mock-ounit PINS=mock:https://github.com/cryptosense/ocaml-mock.git
+    - OCAML_VERSION=4.09 PACKAGE=mock-ounit PINS=mock:https://github.com/cryptosense/ocaml-mock.git

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,11 @@
-v0.1.0
-======
+# Change Log
+
+## 0.1.1
+
+* Use Dune instead of jbuilder.
+* Upgrade to Opam 2.0.
+* Run tests in CI.
+
+## 0.1.0
 
 Initial release.

--- a/mock-ounit.opam
+++ b/mock-ounit.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "Etienne Millon <etienne@cryptosense.com>"
-authors: "Etienne Millon <etienne@cryptosense.com>"
+maintainer: ["Cryptosense <opensource@cryptosense.com>"]
+authors: ["Cryptosense <opensource@cryptosense.com>"]
 homepage: "https://github.com/cryptosense/ocaml-mock"
 bug-reports: "https://github.com/cryptosense/ocaml-mock/issues"
 license: "BSD-2"
@@ -13,7 +13,7 @@ run-test: [
   [ "dune" "runtest" "-p" name "-j" jobs ]
 ]
 depends: [
-  "dune" {build}
+  "dune"
   "mock"
   "ounit"
   "ppx_deriving" {with-test}

--- a/mock.opam
+++ b/mock.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "Etienne Millon <etienne@cryptosense.com>"
-authors: "Etienne Millon <etienne@cryptosense.com>"
+maintainer: ["Cryptosense <opensource@cryptosense.com>"]
+authors: ["Cryptosense <opensource@cryptosense.com>"]
 homepage: "https://github.com/cryptosense/ocaml-mock"
 bug-reports: "https://github.com/cryptosense/ocaml-mock/issues"
 license: "BSD-2"
@@ -10,7 +10,7 @@ build: [
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
-  "dune" {build}
+  "dune"
 ]
 synopsis: "Configurable functions to test impure code"
 description: """


### PR DESCRIPTION
This notably removes the use of `{build}` for Dune in Opam files.