### PR TITLE
Add compatibility with OCaml 5.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,16 +13,16 @@ jobs:
           - ubuntu-latest
         ocaml-compiler:
           - 4.07.x
-          - 5.0.x
+          - 5.2.x
         package:
           - mock
           - mock-ounit
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
       - run: opam install "${{ matrix.package }}.dev" --with-doc --with-test

--- a/src/mock.ml
+++ b/src/mock.ml
@@ -40,11 +40,11 @@ let call mock args =
   | None
     ->
     Stdlib.raise (Mock_not_configured mock.name)
-  | Some effect
+  | Some side_effect
     ->
     begin
       mock.params := args :: !(mock.params);
-      eval_side_effect effect
+      eval_side_effect side_effect
     end
 
 let recorded_calls mock =


### PR DESCRIPTION
This makes this package compatible with compilers which have the `effect` keyword. I could test it locally with the 5.3 alpha.

Closes #9 